### PR TITLE
fix: pass in a RegEx to remove hashes from filenames

### DIFF
--- a/src/app/getLocalFileDetails/index.js
+++ b/src/app/getLocalFileDetails/index.js
@@ -3,7 +3,12 @@ import glob from 'glob'
 import getSize from './getSize'
 import logger from '../../logger'
 
-const getLocalFileDetails = ({ files, defaultCompression }) => {
+const getLocalFileDetails = ({
+    files,
+    defaultCompression,
+    removeHash,
+    hashPattern,
+}) => {
     const fileDetails = {}
 
     files.forEach((file) => {
@@ -24,7 +29,14 @@ const getLocalFileDetails = ({ files, defaultCompression }) => {
                 })
 
                 if (size) {
-                    fileDetails[filePath] = {
+                    let normalizedFilePath = file.path
+
+                    if (removeHash) {
+                        normalizedFilePath = file.path.replace(hashPattern, '')
+                    }
+
+                    paths = glob.sync(normalizedFilePath)
+                    fileDetails[normalizedFilePath] = {
                         maxSize,
                         size,
                         compression,

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -11,10 +11,14 @@ const main = async ({
     bundlewatchServiceHost,
     ci,
     defaultCompression,
+    removeHash = false,
+    hashPattern = /\*.bundle.js/,
 }) => {
     const currentBranchFileDetails = getLocalFileDetails({
         files,
         defaultCompression: defaultCompression,
+        removeHash,
+        hashPattern,
     })
 
     const bundlewatchService = new BundleWatchService({


### PR DESCRIPTION

**What kind of change does this PR introduce?**

New `removeHash` and `hashPattern` args to change i.e. `main.ABC.bundle.js` to `main.bundle.js`.

**Did you add tests for your changes?**

WIP

**If relevant, link to documentation update:**


**Summary**

 This is useful for when you are using i.e. webpack's `[hash]` naming convention for your output bundles.

**Does this PR introduce a breaking change?**

No breaking changes.

**Other information**
